### PR TITLE
Use new version of kostalpyko for piko70

### DIFF
--- a/custom_components/kostal/manifest.json
+++ b/custom_components/kostal/manifest.json
@@ -3,7 +3,7 @@
     "name": "Kostal",
     "documentation": "https://github.com/gieljnssns/kostalpiko-sensor-homeassistant",
     "requirements": [
-        "kostalpyko==0.2"
+        "kostalpyko==0.3"
     ],
     "dependencies": [],
     "codeowners": [


### PR DESCRIPTION
After fixing gieljnssns/KostalPyko#2 by merging gieljnssns/KostalPyko#3 and deploy it to pypy you should use the new version of kostalpyko.

This merge requests is for Kostal Piko7.0 and other inverters with 2 strings.